### PR TITLE
Configurable root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ cd geostyler-rest
 npm install
 
 npm run start-dev
+
+Open http://localhost:8888/geostyler-rest/api-docs/ in a browser
 ```
 
 ### Run unit tests
@@ -31,7 +33,11 @@ npm run test
 ```
 cd /path/to/this/checkout
 
+npm install
+
 npm start
+
+Open http://localhost:8888/geostyler-rest/api-docs/ in a browser
 ```
 
 ### Run with Docker
@@ -42,4 +48,6 @@ cd /path/to/this/checkout
 docker build -t geostyler_rest_server .
 
 docker run -e NODE_API_PORT=9999 -p 9999:9999 geostyler_rest_server
+
+Open http://localhost:9999/geostyler-rest/api-docs/ in a browser
 ```

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@
 const express = require('express');
 
 const port = process.env.NODE_API_PORT || 8888;
+const rootPath = process.env.GS_REST_ROOT_PATH || '/geostyler-rest';
 const app = express();
 
 app.use(function (req, res, next) {
-  var data = '';
+  let data = '';
   req.setEncoding('utf8');
   req.on('data', function (chunk) {
     data += chunk;
@@ -46,8 +47,13 @@ const swaggerOptions = {
     `
 };
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions));
+app.use(`${rootPath}/api-docs`, swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions));
 // END Swagger
+
+// ensure to forward to Swagger UI when root folder is accessed
+app.get(rootPath, (req, res) => {
+  res.redirect(`${rootPath}/api-docs`);
+});
 
 module.exports = app.listen(port, () =>
   console.log(`REST server listening on port ${port}!`)

--- a/route/style.route.js
+++ b/route/style.route.js
@@ -4,12 +4,13 @@
  * @author C. Mayer (meggsimum)
  */
 module.exports = function (app) {
-  const basePath = '/geostyler-rest/rpc/transform';
+  const rootPath = process.env.GS_REST_ROOT_PATH || '/geostyler-rest';
+  const transformRpcPath = `${rootPath}/api/rpc/transform`;
 
   /**
    * Uses GeoStyler to convert between various formats for styling of geographic data.
    */
-  app.post(basePath, async (req, res) => {
+  app.post(transformRpcPath, async (req, res) => {
     const sourceStyle = req.body;
 
     if (!sourceStyle || sourceStyle === '') {

--- a/swagger/spec.json
+++ b/swagger/spec.json
@@ -16,7 +16,7 @@
     },
     "servers": [],
     "paths": {
-        "/geostyler-rest/rpc/transform": {
+        "/geostyler-rest/api/rpc/transform": {
           "post": {
             "summary": "Uses GeoStyler to convert between various formats for styling of geographic data.",
             "produces": [

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -6,7 +6,7 @@ const transformRpcPath = `${rootPath}/api/rpc/transform`;
 
 describe(transformRpcPath, () => {
   it('POST returns JSON from request body', done => {
-    var data = {
+    const data = {
       version: 8,
       name: 'Demo Style',
       layers: [{

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,9 +1,10 @@
 const request = require('supertest');
 const server = require('../index');
 
-const basePath = '/geostyler-rest/rpc/transform';
+const rootPath = process.env.GS_REST_ROOT_PATH || '/geostyler-rest';
+const transformRpcPath = `${rootPath}/api/rpc/transform`;
 
-describe(`${basePath}`, () => {
+describe(transformRpcPath, () => {
   it('POST returns JSON from request body', done => {
     var data = {
       version: 8,
@@ -19,7 +20,7 @@ describe(`${basePath}`, () => {
     };
 
     request(server)
-      .post(basePath + '?sourceFormat=mapbox&targetFormat=sld')
+      .post(transformRpcPath + '?sourceFormat=mapbox&targetFormat=sld')
       .set('Content-Type', 'application/json')
       .send(data)
       .expect('Content-Type', /xml/)


### PR DESCRIPTION
This introduces an ENV VAR `GS_REST_ROOT_PATH`, which allows to configure the root path of the REST API. Default is `/geostyler-rest`.

Also proposes an API path adaption in order to have a better differentiation between the Swagger UI and the API itself. So by merging this the following endpoits are supported:

`http://myserver/geostyler-rest/api-docs/`

`http://myserver/geostyler-rest/api/rpc/transform`
