### PR TITLE
Return "real" JSON for Mapbox target type

### DIFF
--- a/route/style.route.js
+++ b/route/style.route.js
@@ -64,6 +64,9 @@ const sendTargetStyle = (targetStyle, targetFormat, res) => {
   if (targetType === 'application/xml' || targetType === 'text/plain') {
     res.status(200).send(targetStyle);
   } else if (targetType === 'application/json') {
+    if (typeof targetStyle === 'string') {
+      targetStyle = JSON.parse(targetStyle);
+    }
     res.status(200).json(targetStyle);
   }
 }


### PR DESCRIPTION
This ensures that in case of having 'Mapbox' as target type a 'real' JSON object is returned by the REST API. Before a serialized JSON string was returned because it is delivered like this by the `writeStyle` function of the mapbox parser.