### PR TITLE
Add custom CSS and JS hooks for Swagger UI

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,16 @@ const swaggerOptions = {
       background-position-x: right;
       background-size: 300px;
     }
-    `
+    `,
+  customCssUrl: '/static/swagger-ui-custom.css',
+  customJs: '/static/swagger-ui-custom.js'
 };
 
 app.use(`${rootPath}/api-docs`, swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions));
 // END Swagger
+
+// serve files in the static folder
+app.use('/static', express.static('static'));
 
 // ensure to forward to Swagger UI when root folder is accessed
 app.get(rootPath, (req, res) => {

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,16 @@
+# static folder
+
+The files placed in this 'static' folder are served by the API's HTTP server.
+
+In case you place a file 'foo.txt' it will be served at
+http://localhost:8888/static/foo.txt
+
+## Adjust Swagger UI
+
+If you want to customize the Swagger UI you can place the files
+
+  - swagger-ui-custom.css
+  - swagger-ui-custom.js
+
+in this folder. These files are automatically loaded and applied to the
+Swagger UI.


### PR DESCRIPTION
This adds custom CSS and JS hook files in order to customize the Swagger UI.

Place the files `swagger-ui-custom.css` and/or `swagger-ui-custom.js` in the `static` folder. These files are automatically loaded and applied to the Swagger UI.