### PR TITLE
fix: parse input even on identical source and target formats

### DIFF
--- a/route/style.route.js
+++ b/route/style.route.js
@@ -112,17 +112,12 @@ module.exports = function (app) {
     const targetParser = getParserFromUrlParam(targetFormat);
 
     if (sourceParser === undefined) {
-      res.status(400).json({ msg: 'Error reading source format', details: 'Unknown "sourceFormat"'});
+      res.status(400).json({ msg: 'Error reading source format', details: 'Unknown "sourceFormat"' });
       return;
     }
 
     if (targetParser === undefined) {
-      res.status(400).json({ msg: 'Error reading target format', details: 'Unknown "targetFormat"'});
-      return;
-    }
-
-    if (sourceFormat.toLowerCase() === targetFormat.toLowerCase()) {
-      sendTargetStyle(sourceStyle, sourceFormat, res);
+      res.status(400).json({ msg: 'Error reading target format', details: 'Unknown "targetFormat"' });
       return;
     }
 
@@ -130,6 +125,12 @@ module.exports = function (app) {
     const readResponse = await sourceParser.readStyle(sourceStyle);
     if (Array.isArray(readResponse.errors) && readResponse.errors.length) {
       res.status(400).json({ msg: 'Error reading input', details: readResponse?.errors?.[0]?.message || '' });
+      return;
+    }
+
+    // send back the input if sourceFormat equals targetFormat
+    if (sourceFormat.toLowerCase() === targetFormat.toLowerCase()) {
+      sendTargetStyle(sourceStyle, sourceFormat, res);
       return;
     }
 

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -123,6 +123,18 @@ describe(`${transformRpcPath}`, () => {
       .expect(200, done);
   });
 
+  it('returns 400 for equal source and target format with nonsense input', done => {
+    request(server)
+      .post(transformRpcPath + '?sourceFormat=mapbox&targetFormat=mapbox')
+      .set('Content-Type', 'application/json')
+      .send('some nonsense data')
+      .expect('Content-Type', /json/)
+      .expect((res) => {
+        assert.strictEqual(res.body.msg, 'Error reading input');
+      })
+      .expect(400, done);
+  });
+
   it('returns Mapbox JSON', done => {
     request(server)
       .post(transformRpcPath + '?sourceFormat=sld&targetFormat=mapbox')


### PR DESCRIPTION
Avoid crashes when requesting same `sourceFormat` and `targetFormat` with an input that doesn't make sense for this format.

1 test added.