### PR TITLE
fix: set proper identifier for json conformance

### DIFF
--- a/src/routes/ogc.ts
+++ b/src/routes/ogc.ts
@@ -182,7 +182,7 @@ export const conformance: Handler = async ({
   return {
     conformsTo: [
       'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/core',
-      'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/json',
+      'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/json',
       'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/manage-styles',
       'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/mapbox-styles',
       'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/sld-10',


### PR DESCRIPTION
According to https://docs.ogc.org/DRAFTS/20-009.html#conformance_declaration the conformance for handling json requests should be 'http://www.opengis.net/spec/ogcapi-common-1/1.0/req/json'.

![image](https://github.com/user-attachments/assets/0ddb342e-8f29-4f6c-9a52-f0048276cc16)
