### PR TITLE
ci: add release workflow using semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-name: Create and publish Docker image
+name: Release
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -20,6 +18,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Prepare git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Release 🚀
+        uses: cycjimmy/semantic-release-action@v4.2.0
+        id: semantic
+        env:
+          # We use a PAT here since GITHUB_TOKEN does not
+          # trigger other workflows (e.g. updating gh-pages,
+          # notification to Discord, etc.)
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+        with:
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/changelog
 
       - name: Log in to the Container registry
         uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
@@ -40,5 +56,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags:
+            - ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            - ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semantic.outputs.new_release_version }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,31 @@
+{
+  "branches": ["main", {"name": "beta", "prerelease": true}],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "header": "Changelog of GeoStyler REST"
+        }
+      }
+    ],
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md", "package.json", "bun.lockdb"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
This adds a semantic release workflow with manual trigger of the pipeline.

This will not publish to the npm registry, but create a tag, build and publish the docker image based on the tag, and maintain a changelog.